### PR TITLE
Fix: Scope query selectors to allow nested Tabs blocks

### DIFF
--- a/src/tabs/view.js
+++ b/src/tabs/view.js
@@ -1,6 +1,10 @@
 document.addEventListener( 'DOMContentLoaded', function () {
 	const cloudCatchTabs = ( tabsWrapper ) => {
-		const tabLabels = tabsWrapper.querySelectorAll( '[role="tab"]' );
+		const tabLabels = Array.from(
+			tabsWrapper.querySelectorAll( '[role="tab"]' )
+		).filter(
+			( el ) => el.closest( '.wp-block-cloudcatch-tabs' ) === tabsWrapper
+		);
 
 		for ( let x = 0; x < tabLabels.length; x++ ) {
 			tabLabels[ x ].addEventListener( 'focus', focusEventHandler );
@@ -62,8 +66,14 @@ document.addEventListener( 'DOMContentLoaded', function () {
 		};
 
 		const setActiveTab = ( id ) => {
-			tabsWrapper
-				.querySelectorAll( 'div[tabid]:not([role="tab"])' )
+			Array.from(
+				tabsWrapper.querySelectorAll( 'div[tabid]:not([role="tab"])' )
+			)
+				.filter(
+					( el ) =>
+						el.closest( '.wp-block-cloudcatch-tabs' ) ===
+						tabsWrapper
+				)
 				.forEach( ( tab ) => {
 					tab.style.display = 'none';
 					tab.classList.remove( 'active' );
@@ -76,21 +86,27 @@ document.addEventListener( 'DOMContentLoaded', function () {
 
 			activeIndex = parseInt( id );
 
-			const currentTabLabel = tabsWrapper.querySelector(
-				'[role="tab"][tabid="' + activeIndex + '"]'
+			const currentTabLabel = tabLabels.find(
+				( label ) => parseInt( label.getAttribute( 'tabid' ) ) === activeIndex
 			);
 
-			currentTabLabel.classList.add( 'active' );
-			currentTabLabel.setAttribute( 'aria-selected', 'true' );
+			if ( currentTabLabel ) {
+				currentTabLabel.classList.add( 'active' );
+				currentTabLabel.setAttribute( 'aria-selected', 'true' );
+			}
 
-			tabsWrapper.querySelector(
-				'div[tabid="' + activeIndex + '"]:not([role="tab"])'
-			).style.display = 'block';
-			tabsWrapper
-				.querySelector(
+			const currentTabPanel = Array.from(
+				tabsWrapper.querySelectorAll(
 					'div[tabid="' + activeIndex + '"]:not([role="tab"])'
 				)
-				.classList.add( 'active' );
+			).find(
+				( el ) => el.closest( '.wp-block-cloudcatch-tabs' ) === tabsWrapper
+			);
+
+			if ( currentTabPanel ) {
+				currentTabPanel.style.display = 'block';
+				currentTabPanel.classList.add( 'active' );
+			}
 
 			const event = new CustomEvent( 'tabChanged', { // eslint-disable-line
 				detail: currentTabLabel,


### PR DESCRIPTION
## Description
This PR addresses a bug where nesting a Tabs block inside another Tabs block causes the component's JavaScript to break or act unexpectedly. 

The original code used broad DOM queries (`querySelectorAll` and `querySelector`) which inadvertently selected all descendant tabs and content panels, meaning the parent tab logic was interfering with the display and active states of the nested child tabs.

## Solution
Updated the logic in `src/tabs/view.js` to ensure each instance of the tabs block only interacts with its immediate children:
- Selected `[role="tab"]` elements and `div[tabid]` panels are now filtered using `.closest('.wp-block-cloudcatch-tabs') === tabsWrapper`.
- Swapped `querySelector` for `.find()` on these filtered arrays to locate the correct active tab label and panel safely.

## Impact
Users can now safely place Tab blocks inside of other Tab blocks to build more complex and nested layouts, and each level of tabs will function completely independently without CSS/JS conflicts.
